### PR TITLE
[sc-15461] Revert detect commit

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,13 +1,2 @@
 #!/bin/sh
-if [ -f $1/Gemfile ]; then
-	GEMFILE=$(ls | grep Gemfile)
-	GEMLEN=${#GEMFILE}
-	if [ GEMLEN -ne 0 ]; then
-		echo "RTesseractFramework"
-		exit 0
-	else
-		exit 1
-	fi
-else
-	exit 1
-fi
+echo "RTesseractFramework"


### PR DESCRIPTION
Previous commit which attempted to stop buildpack from applying if it was not in a ruby project with tesseract did not work. Reverting it here.